### PR TITLE
Add not unlocked item tracking with wishlist (compatibility for MoreCheckmarks mod)

### DIFF
--- a/config.json
+++ b/config.json
@@ -54,5 +54,6 @@
         "5910968f86f77425cf569c32"
     ],
     "requireUnlockComponents": false,
-    "debug": false
+    "debug": false,
+    "useWishList": false
 }

--- a/runtest.bat
+++ b/runtest.bat
@@ -1,0 +1,11 @@
+@echo off
+echo Running build
+call npm run build
+
+REM Copy the files to the local directory
+REM Local bronzeman mod directory
+set bronzemanDir=C:\Games\SPT-AKI\user\mods\kcy-bronzeman-1.1.2\src
+
+REM Copy each file pattern individually
+echo Copying .ts files
+copy /Y dist\src\*.ts %bronzemanDir%

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -311,7 +311,7 @@ class BronzemanMod {
     // Player wishlist reinitialisation
     // This is necessary to do when the user adds/removes items from the game
     // Now it's done on every profile load (Game start)
-    // TODO: Do this on server start instead of every profile load
+    // TODO: Do this on server start instead of every profile load?
     public onProfileLoad(sessionID: string) {
         const profile = this.saveServer.getProfile(sessionID);
 
@@ -322,6 +322,11 @@ class BronzemanMod {
         const itemsForWishlist = [];
         this.itemHelper.getItems().forEach(i => {
             // if category[] includes the item parent, remove it from the wishlist
+            // also do not add items that are:
+            // - in the ignoreItems list
+            // - in the unlocked list
+            // - quest items
+            // - ammo boxes
             if (!this.isParentIncludedInIngnoredCategories(i._id) && !this.categories.includes(i._id) && !config.ignoreItems.includes(i._id) && !unlocked.includes(i._id) && i._parent !== "543be5cb4bdc2deb348b4568" && !i._props.QuestItem === true) {
                 itemsForWishlist.push(i._id);
             }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -49,6 +49,19 @@ export class Bronzeman implements IPreAkiLoadMod, IPostDBLoadMod {
         const dynamicRouterModService = container.resolve<DynamicRouterModService>("DynamicRouterModService");
         const httpResponseUtil = container.resolve<HttpResponseUtil>("HttpResponseUtil");
 
+        if (config.useWishList) {
+            staticRouterModService.registerStaticRouter("BronzemanProfileLoad",
+                [{
+                    url: "/client/game/start",
+                    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+                    action: (url: string, info: any, sessionId: string, output: string) => {
+                        bronzeman.onProfileLoad(sessionId);
+                        return output;
+                    }
+                }], "aki"
+            );
+        }
+
         // Initialise player on proflie load
         if (config.unlocks.inventory) {
             staticRouterModService.registerStaticRouter("BronzemanProfileList", [
@@ -256,7 +269,8 @@ class BronzemanMod {
     constructor(
         @inject("WinstonLogger") private logger: ILogger,
         @inject("SaveServer") private saveServer: SaveServer,
-        @inject("ItemHelper") private itemHelper: ItemHelper
+        @inject("ItemHelper") private itemHelper: ItemHelper,
+        @inject("TraderHelper") private traderhelper: TraderHelper
     ) {
         // Allow ignored categories
         if (config.ignoreCategories.keys) this.categories.push("543be5e94bdc2df1348b4568");
@@ -290,7 +304,51 @@ class BronzemanMod {
         const profile = this.saveServer.getProfile(sessionID);
 
         this.itemCheck(profile);
-        this.checkInventory(profile);  
+        this.checkInventory(profile);
+        this.logger.info(`[bronzeman] Initialised player ${profile.info.username} (${sessionID})`);
+    }
+
+    // Player wishlist reinitialisation
+    // This is necessary to do when the user adds/removes items from the game
+    // Now it's done on every profile load (Game start)
+    // TODO: Do this on server start instead of every profile load
+    public onProfileLoad(sessionID: string) {
+        const profile = this.saveServer.getProfile(sessionID);
+
+        const unlocked = profile["bronzemanItems"];
+        const wishlist = profile.characters.pmc.WishList;
+        
+        // Go through items in the game and filter out the ones that are unlocked, in the wishlist, or in the ignored categories
+        const itemsForWishlist = [];
+        this.itemHelper.getItems().forEach(i => {
+            // if category[] includes the item parent, remove it from the wishlist
+            if (!this.isParentIncludedInIngnoredCategories(i._id) && !this.categories.includes(i._id) && !config.ignoreItems.includes(i._id) && !unlocked.includes(i._id) && i._parent !== "543be5cb4bdc2deb348b4568" && !i._props.QuestItem === true) {
+                itemsForWishlist.push(i._id);
+            }
+        });
+        // Assign the new wishlist to the profile
+        profile.characters.pmc.WishList = itemsForWishlist;
+        // Log the changes
+        const origCount = wishlist.length;
+        this.logger.info(`[bronzeman] Removed ${origCount - profile.characters.pmc.WishList.length} unlocked items from wishlist for ${profile.info.username} (${sessionID})`);
+    }
+
+    public isParentIncludedInIngnoredCategories(item: string): boolean {
+        const [valid, checkItem] = this.itemHelper.getItem(item);
+        if (!valid) {
+            console.log(`Failed to get item: ${item}`);
+            return false; // Assuming false as default if item can't be fetched
+        }
+        console.log(`Checking item: ${item}, Parent: ${checkItem._parent}`);
+        if (checkItem._parent === "") {
+            console.log(`Reached top parent for item: ${item}`);
+            return false;
+        }
+        if (this.categories.includes(checkItem._parent)) {
+            console.log(`Item: ${item} is ignored due to parent: ${checkItem._parent}`);
+            return true;
+        }
+        return this.isParentIncludedInIngnoredCategories(checkItem._parent);
     }
 
     public getPlayer(sessionID: string): IAkiProfile {
@@ -317,6 +375,13 @@ class BronzemanMod {
             if (profile["bronzemanItems"].includes(item._tpl)) continue;
             // Unlock item
             profile["bronzemanItems"].push(item._tpl);
+            // Remove the unlocked item from the wishlist
+            if (config.useWishList) {
+                const index = profile.characters.pmc.WishList.indexOf(item._tpl);
+                if (index > -1) {
+                    profile.characters.pmc.WishList.splice(index, 1);
+                }
+            }
             if (config.debug) {
                 const name = this.itemHelper.getItemName(item._tpl);
                 this.logger.logWithColor(`[bronzeman] Unlocking: (${item._tpl}) ${name}`, LogTextColor.WHITE, LogBackgroundColor.GREEN);
@@ -336,6 +401,10 @@ class BronzemanMod {
         }
 
         return [...profile["bronzemanItems"], ...this.categories, ...config.ignoreItems];
+    }
+
+    public getAllCategoryItems(category: string): string[] {
+        return this.itemHelper.getItems().filter(i => i._parent === category).map(i => i._id);
     }
 
     public canPurchase(profile: IAkiProfile, item: string): boolean {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -341,16 +341,16 @@ class BronzemanMod {
     public isParentIncludedInIngnoredCategories(item: string): boolean {
         const [valid, checkItem] = this.itemHelper.getItem(item);
         if (!valid) {
-            console.log(`Failed to get item: ${item}`);
+            if (config.debug) this.logger.info(`[bronzeman] Failed to get item: ${item}`);
             return false; // Assuming false as default if item can't be fetched
         }
-        console.log(`Checking item: ${item}, Parent: ${checkItem._parent}`);
+        if (config.debug) this.logger.info(`[bronzeman] Checking item: ${item}, Parent: ${checkItem._parent}`);
         if (checkItem._parent === "") {
-            console.log(`Reached top parent for item: ${item}`);
+            if (config.debug) this.logger.info(`[bronzeman] Reached top parent for item: ${item}`);
             return false;
         }
         if (this.categories.includes(checkItem._parent)) {
-            console.log(`Item: ${item} is ignored due to parent: ${checkItem._parent}`);
+            if (config.debug) this.logger.info(`[bronzeman] Item: ${item} is ignored due to parent: ${checkItem._parent}`);
             return true;
         }
         return this.isParentIncludedInIngnoredCategories(checkItem._parent);


### PR DESCRIPTION
Use wishlist to track items that are not unlocked. Works together with MoreCheckmarks mod and Amands Sense.

New config option to turn on feature: `useWishList`. False by default.

When feature is turned on:
- On profile load, generates player wishlist automatically from items database overwriting the existing wishlist (works with mods that add new items)
- Excludes quest items, ignored items and ignored categories, ammo boxes, and items that are already unlocked (bronzemanItems)
- Mod compatibility: 
  - MoreCheckmarks mod: All items that are not yet unlocked show blue wishlist checkmark
  - Amands Sense: Wishlisted (not unlocked) items have their own glow color, which makes them more detectable
  
When wishlist is on, it is reset each profile load (to update it if something broke, to match unlocked items in bronzeman if those are changed manually, and to match the items in the database when eg. adding mods that add items)